### PR TITLE
Fix spacing of "# Curses and Ruby"

### DIFF
--- a/_posts/2014-01-21-ruby-and-curses-tutorial.markdown
+++ b/_posts/2014-01-21-ruby-and-curses-tutorial.markdown
@@ -29,7 +29,7 @@ level of tutorial for curses as it is in [Python documentation][5]. I don't
 think that a Rubyist should look at the original C documentation of *curses* to
 start with curses ruby binding.
 
-#Curses and Ruby
+# Curses and Ruby
 
 Basically, curses is an old library distributed on many Unix distribution whose
 goal was to manipulate a terminal screen to draw windows, to display some text


### PR DESCRIPTION
Hi @stac47.

I was reading [your tutorial on curses](https://stac47.github.io/ruby/curses/tutorial/2014/01/21/ruby-and-curses-tutorial.html) and noticed that I think you meant this section to be a header.

Anyway - great post, thank you for writing it!